### PR TITLE
APPS-4 Fix favicon on children pages

### DIFF
--- a/apps_bundle_build.py
+++ b/apps_bundle_build.py
@@ -15,6 +15,11 @@ STREAMLIT_PAGE_TEMPLATE =  textwrap.dedent(
     {front_imports}
     {back_imports}
 
+    # Set Page Config
+    st.set_page_config(
+        page_icon="./favicon.png",
+        layout="wide",
+    )
     
     # Start backend (if any)
     st.cache_resource({back_callable})(page_endpoint={page_endpoint})


### PR DESCRIPTION
# APPS-4 Fix favicon on children pages

* Closes: #4 

Call `st.set_page_config` in the children page template to ensure the favicon is correctly defined. 